### PR TITLE
Fix key name of dotless i character

### DIFF
--- a/zmk_locale_generator/codepoints.yaml
+++ b/zmk_locale_generator/codepoints.yaml
@@ -255,7 +255,7 @@ z: Z
 "\u012E": [I_OGONEK, I_OGON]                    # Į
 "\u012F": [I_OGONEK, I_OGON]                    # į
 "\u0130": I_DOT                                 # İ
-"\u0131": I_DOT                                 # ı
+"\u0131": I_DOTLESS                             # ı
 "\u0132": IJ                                    # Ĳ
 "\u0133": IJ                                    # ĳ
 "\u0134": [J_CIRCUMFLEX, J_CIRC]                # Ĵ


### PR DESCRIPTION
Small fix for the key name for "ı", which is the dotless i and not the lower case version of dotted i, "İ". Upper case of former is the ASCII "I" and lower case of latter is "i", at least for Turkish.

[Latin Small Letter dotless I](https://en.wikipedia.org/wiki/Dotless_I)

<html><body>
<!--StartFragment-->

U+0131 | ı | 305 | &inodot; | Latin Small Letter dotless I | 0241
-- | -- | -- | -- | -- | --

<!--EndFragment-->
</body>
</html>

