### PR TITLE
Update `pipx` command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can now use the key codes defined in the header in your keymap bindings. For
 Install [Pipx](https://pipx.pypa.io/stable/), then use it to install ZMK Locale Generator:
 
 ```sh
-pipx install https://github.com/joelspadin/zmk-locale-generator.git
+pipx install git+https://github.com/joelspadin/zmk-locale-generator.git
 ```
 
 ### Usage


### PR DESCRIPTION
I had to use `pipx install git+https://...` for the installation to work. (pipx 1.7.1 on fedora 40)