### PR TITLE
Add macOS Swedish keyboard layouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ zmk_locale_generator = [
     "keyboards/*",
     "keyboards/cldr/unicode-license.txt",
     "keyboards/cldr/keyboards/windows/*",
+    "keyboards/cldr/keyboards/osx/*",
 ]
 
 [tool.setuptools_scm]

--- a/zmk_locale_generator/keyboards/keyboards.yaml
+++ b/zmk_locale_generator/keyboards/keyboards.yaml
@@ -414,6 +414,12 @@
 - path: cldr/keyboards/windows/sv-t-k0-windows.xml
 - path: cldr/keyboards/windows/sv-t-k0-windows-extended.xml
   filename: sv_sami
+- path: cldr/keyboards/osx/sv-t-k0-osx-extended.xml
+  filename: sv_mac
+- path: cldr/keyboards/osx/sv-t-k0-osx.xml
+  filename: sv_mac_legacy
+- path: cldr/keyboards/osx/sv-t-k0-osx-extended-var.xml
+  filename: sv_mac_sami
 
 # Syriac
 - path: cldr/keyboards/windows/syr-t-k0-windows.xml


### PR DESCRIPTION
Adds three macOS Swedish layouts from the CLDR osx definitions:

- `sv_mac`
  - sv-t-k0-osx-extended.xml ("Swedish" in macOS, formerly "Swedish - Pro")
- `sv_mac_legacy`
  - sv-t-k0-osx.xml ("Swedish Legacy" in macOS, formerly "Swedish")
- `sv_mac_sami`
  - sv-t-k0-osx-extended-var.xml (Sami variant)

Also adds `keyboards/cldr/keyboards/osx/*` to pyproject.toml package-data, required for the generator to find the osx folder at runtime.